### PR TITLE
fix(points and pairings components)

### DIFF
--- a/src/Components/Points/Points.jsx
+++ b/src/Components/Points/Points.jsx
@@ -2,7 +2,6 @@ import axios from "axios";
 import { useParams } from "react-router-dom";
 
 import { useState, useEffect, useCallback } from "react";
-import { API_URL } from "../../constants/API_URL";
 
 import styles from "./Points.module.css";
 import React from "react";
@@ -38,8 +37,6 @@ export const Points = ({ pairings, participantsData, tournamentStatus }) => {
       }
 
       let message = "";
-
-      console.log("Winners list: ", winnersList);
 
       if (winnersList.length === 1) {
         const message = `${winnersList[0]} has won the tournament!`;
@@ -90,7 +87,7 @@ export const Points = ({ pairings, participantsData, tournamentStatus }) => {
   useEffect(() => {
     calculateStudentPointsPerRound();
     calculateWinner();
-  }, []);
+  }, [calculateStudentPointsPerRound, calculateWinner]);
 
   return (
     <div className={styles.points}>


### PR DESCRIPTION
- Make the number of matches completed be set in a function inside of a useEffect hook. This solves the problem of having the number of matches completed reset to 0 whenever switching between the Points and Pairings components, which was causing the “Start next round” button to not appear.

- Fix the issue of the wrong winner being displayed on the Points page when the tournament is finished. The participantsData should be updated when clicking the “Finish tournament” button.