### PR TITLE
fix(create pairings): Wrong data sent to server

### DIFF
--- a/src/Components/Pairings/Pairings.jsx
+++ b/src/Components/Pairings/Pairings.jsx
@@ -80,6 +80,18 @@ export const Pairings = ({
 
         onUpdatePairingsData(updatedResults);
 
+        const tournamentDetailsResponse = await axios.get(
+          `${API_URL}/tournaments/${tournamentId}`,
+          {
+            headers: { Authorization: `Bearer ${storedAuthToken}` },
+          }
+        );
+
+        const updatedParticipantsData =
+          tournamentDetailsResponse.data.participantsData;
+
+        onUpdateParticipantsData(updatedParticipantsData);
+
         setMatchesCompleted(matchesCompleted + 1);
 
         return;
@@ -113,6 +125,18 @@ export const Pairings = ({
         const updatedResults = response.data;
 
         onUpdatePairingsData(updatedResults);
+
+        const tournamentDetailsResponse = await axios.get(
+          `${API_URL}/tournaments/${tournamentId}`,
+          {
+            headers: { Authorization: `Bearer ${storedAuthToken}` },
+          }
+        );
+
+        const updatedParticipantsData =
+          tournamentDetailsResponse.data.participantsData;
+
+        onUpdateParticipantsData(updatedParticipantsData);
 
         setMatchesCompleted(matchesCompleted + 1);
         return;


### PR DESCRIPTION
- Update the participant data inside the handleWin and handleDraw functions. At the moment, the wrong data is being sent to the server, which generates an incorrect pairing for the next round.